### PR TITLE
ascp.sh: quote args

### DIFF
--- a/ascp.sh
+++ b/ascp.sh
@@ -12,11 +12,11 @@ echo /home/data/.aspera/connect/bin/ascp \
     -l "$ASCP_LIMIT" \
     -i "$ASCP_KEY" \
     "$@" \
-    $STUDY@$ASCP_SERVER:$SOURCE $TARGET
+    "$STUDY@$ASCP_SERVER:$SOURCE" "$TARGET"
 
 /home/data/.aspera/connect/bin/ascp \
     -P$ASCP_PORT \
     -l "$ASCP_LIMIT" \
     -i "$ASCP_KEY" \
     "$@" \
-    $STUDY@$ASCP_SERVER:$SOURCE $TARGET
+    "$STUDY@$ASCP_SERVER:$SOURCE" "$TARGET"


### PR DESCRIPTION
Filenames with spaces weren't handled.
```
$ docker run -ti --rm -v /tmp/data/idr0018:/data imagedata/download idr0018 "20160503-neff-disk/RawDataTCP-linesWP6final/BAZLA-TCP/Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi" /data
ascp: "user@host:" in all sources must match
Startup failed, exit
```
To test:
`docker run -ti --rm -v /tmp/data/idr0018:/data aspera-client-docker idr0018 "20160503-neff-disk/RawDataTCP-linesWP6final/BAZLA-TCP/Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi" /data`