### PR TITLE
Adding documentation and additional command line options to ascp.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN true \
 
 ENV ASCP_KEY /home/data/.aspera/connect/etc/asperaweb_id_dsa.openssh
 ENV ASCP_LIMIT 40m
+ENV ASCP_RETRANSFER_FILE 0
 ENV ASCP_PORT 33001
 ENV ASCP_SERVER fasp.ebi.ac.uk
 ADD ascp.sh /usr/local/bin/ascp.sh

--- a/README.md
+++ b/README.md
@@ -32,3 +32,25 @@ Some exemplary source directories are listed below:
 | idr0030 | 20170110-original/200972726[5176]_kinome_YAP_TAZ/MeasurementIndex.ColumbusIDX.xml                           | 200972726[5176]_kinome_YAP_TAZ              | 13G  |
 | idr0034 | 20170421-original/Nathalie/HipSci Experiment 10 Plate 1__2014-08-21T17_57_35-Measurement1                   | experiment_10                               | 5.1G |
 
+## Docker environment variables
+
+Calling `docker run` as above envokes `ascp` to download the specified IDR dataset.
+
+Note that you can modify the environment variables in the dockerfile directly in the command line.
+For example, to increase the download rate to `100 Mbps`, add an environment variable to the `docker run` command line:
+
+```bash
+docker run -ti --rm -v /tmp/data:/data -e ASCP_LIMIT=100m imagedata/download idr0001 20151116-verified/JL_120731_S6A /data/JL_120731_S6A
+```
+
+You can modify additional variables as well
+
+| Variable | ASCP flag | Default | Description |
+| :------- | :-------- | :------ | :---------- |
+| ASCP_KEY | `-i` | /home/data/.aspera/connect/etc/asperaweb_id_dsa.openssh | private_key_file |
+| ASCP_LIMIT | `-l` | 40m | max_rate |
+| ASCP_RETRANSFER_FILE | `-k` | 0 | Transfer file overwrite |
+| ASCP_PORT | `-P` | 33001 | ssh-port|
+| ASCP_SERVER | NA | fasp.ebi.ac.uk | host |
+
+For a more detailed description of these commands, see the [ascp documentation](https://www.ibm.com/docs/en/aci/3.9.2?topic=ascp-command-reference).

--- a/ascp.sh
+++ b/ascp.sh
@@ -6,6 +6,13 @@ set -u
 STUDY=$1; shift
 SOURCE=$1; shift
 TARGET=$1; shift
+ASCP_OPTION_LIMIT=$1; shift
+
+# If ASCP_OPTION_LIMIT is provided, then reset ASCP environment variable limit
+# that was set in the Dockerfile
+if [[ -n $ASCP_OPTION_LIMIT ]]; then
+  ASCP_LIMIT=$ASCP_OPTION_LIMIT
+fi
 
 echo /home/data/.aspera/connect/bin/ascp \
     -P$ASCP_PORT \

--- a/ascp.sh
+++ b/ascp.sh
@@ -6,18 +6,12 @@ set -u
 STUDY=$1; shift
 SOURCE=$1; shift
 TARGET=$1; shift
-ASCP_OPTION_LIMIT=$1; shift
-
-# If ASCP_OPTION_LIMIT is provided, then reset ASCP environment variable limit
-# that was set in the Dockerfile
-if [[ -n $ASCP_OPTION_LIMIT ]]; then
-  ASCP_LIMIT=$ASCP_OPTION_LIMIT
-fi
 
 echo /home/data/.aspera/connect/bin/ascp \
     -P$ASCP_PORT \
     -l "$ASCP_LIMIT" \
     -i "$ASCP_KEY" \
+    -k "$ASCP_RETRANSFER_FILE" \
     "$@" \
     "$STUDY@$ASCP_SERVER:$SOURCE" "$TARGET"
 
@@ -25,5 +19,6 @@ echo /home/data/.aspera/connect/bin/ascp \
     -P$ASCP_PORT \
     -l "$ASCP_LIMIT" \
     -i "$ASCP_KEY" \
+    -k "$ASCP_RETRANSFER_FILE" \
     "$@" \
     "$STUDY@$ASCP_SERVER:$SOURCE" "$TARGET"


### PR DESCRIPTION
Thanks for releasing this docker file, and providing documentation for use on the [IDR website](https://idr.openmicroscopy.org/about/download.html).

I'd like to use the docker command to download images of individual plates, but it is likely that the hardcoded limit of 40m will prevent complete downloads. 

https://github.com/IDR/aspera-client-docker/blob/888540176f36bc5f6878da59df9f4037cc693f3e/Dockerfile#L19

In this PR, I've added an option to run the docker image with an *optional* fourth command line argument to enable the user to specify the limit. This option is available for directly using the `ascp` command, but I'd prefer to contain this interaction inside docker.

Thanks!