### PR TITLE
Add GitHub workflow logic for pushing Docker images on tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,3 +16,36 @@ jobs:
         run: docker build -t aspera-client .
       - name: Test
         run: docker run --rm aspera-client idr0001 md5sum.txt /tmp/idr0001/
+  upload:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    env:
+      name: imagedata/download
+    steps:
+      - name: Get prefix
+        id: getprefix
+        run: |
+          if [ ! -z ${{ env.name }} ]; then
+            echo "::set-output name=prefix::${{ env.name }}:"
+          else
+            echo "::set-output name=prefix::${{ github.repository }}:"
+          fi
+      - name: Get other tags
+        id: gettags
+        uses: jupyterhub/action-major-minor-tag-calculator@v1.1.0
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          prefix: "${{ steps.getprefix.outputs.prefix }}"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}
+          push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
         run: docker run --rm aspera-client idr0001 md5sum.txt /tmp/idr0001/
   upload:
     needs: build
-    if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     env:
       name: imagedata/download
@@ -48,4 +47,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}
-          push: true
+          push: ${{ startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+        if: startsWith(github.ref, 'refs/tags')
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
This should address the publication issues raised in https://github.com/IDR/aspera-client-docker/pull/3 by adding the publication logic to the GitHub workflow